### PR TITLE
Make tests runnable: really put MailActionExecuter into test mode

### DIFF
--- a/src/test/java/com/itdhq/inform/policy/test/InformPolicyTest.java
+++ b/src/test/java/com/itdhq/inform/policy/test/InformPolicyTest.java
@@ -98,6 +98,9 @@ public class InformPolicyTest extends TestCase
     @Autowired
     @Qualifier("ContentService")
     private ContentService contentService;
+    
+    @Autowired
+    private ApplicationContext ctx;
 
     @Test
     public void testWiring()
@@ -111,14 +114,11 @@ public class InformPolicyTest extends TestCase
     {
         log.debug("before");
 
-        ApplicationContext context = ApplicationContextHelper.getApplicationContext();
-        ACTION_EXECUTER = context.getBean("OutboundSMTP", ApplicationContextFactory.class).getApplicationContext().getBean("mail", MailActionExecuter.class);
-
-        if (null != ACTION_EXECUTER) {
-            log.debug(ACTION_EXECUTER.toString());
-        }
+        ACTION_EXECUTER = ctx.getBean("OutboundSMTP", ApplicationContextFactory.class)
+                .getApplicationContext().getBean("mail", MailActionExecuter.class);
         WAS_IN_TEST_MODE = ACTION_EXECUTER.isTestMode();
         ACTION_EXECUTER.setTestMode(true);
+        ACTION_EXECUTER.resetTestSentCount();
 
         /*
         InputStream in = this.getClass().getClassLoader()
@@ -237,10 +237,8 @@ public class InformPolicyTest extends TestCase
             log.debug("Versions : " + (String) version.getVersionProperty("creator"));
         }
 
-
-        //TODO FUCKING HARD BITCH!!!!!
-        //MimeMessage message = ACTION_EXECUTER.retrieveLastTestMessage();
-        //Assert.assertNotNull(message);
+        int numberOfMessages = ACTION_EXECUTER.getTestSentCount();
+        Assert.assertEquals("Correct number of messages during the test", 8, numberOfMessages);
     }
 
     @After


### PR DESCRIPTION
Changes:
- do not send emails, make tests runnable
- check number of emails sent (not just the last message) to make test result more or less reasonable

Details regarding Alfresco & Spring magic:
- https://forums.alfresco.com/forum/developer-discussions/content-modeling/acquiring-applicationcontext-inside
- http://stackoverflow.com/questions/21553120/how-does-applicationcontextaware-work-in-spring

Code from https://github.com/Alfresco/community-edition/blob/master/projects/repository/source/test-java/org/alfresco/repo/action/executer/AbstractMailActionExecuterTest.java does not work since it's the code from the test for Alfresco subsystem.

As we see, init procedures of (a) tests for Alfresco components and (b) tests for Alfresco extensions are different. As far as I understand, the first ones are run *without* Alfresco actually, while the latter ones are run *on top of* Alfresco.